### PR TITLE
Fix "Package libc6:amd64 not installed"

### DIFF
--- a/deb2snap
+++ b/deb2snap
@@ -109,7 +109,7 @@ done
 
 function get_pkg_for_file()
 {
-    dpkg -S $@ 2>/dev/null | sed 's/: .*//'
+    dpkg -S $@ 2>/dev/null | awk -F: '{print $1}'
 }
 
 function get_pkgs_from_ldd()


### PR DESCRIPTION
Drop ":ARCH" before passing it to ./tools/dep-tree

```
$ bash -x ./deb2snap -d 15.04 hello
...
++ dpkg -S /lib/x86_64-linux-gnu/libc.so.6
++ sed 's/: .*//'
+ PACKAGES=' hello libc6:amd64'
...
++ ./tools/dep-tree --manifest /home/ubuntu/.cache/snappy-preload/manifests/ubuntu-core-15.04-core-amd64.manifest hello libc6:amd64
Package libc6:amd64 not installed
```